### PR TITLE
Branch ButtonCommands

### DIFF
--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -264,22 +264,13 @@ namespace DiskpartGUI.ViewModels
         public void SetReadOnly()
         {
             masterbuttonsenabled = false;
+            ReadOnlyFunction function;
             if (SelectedVolume.IsReadOnly())
-                SetReadOnly(ReadOnlyFunction.CLEAR);
+                function = ReadOnlyFunction.CLEAR;
             else
-                SetReadOnly(ReadOnlyFunction.SET);
-            masterbuttonsenabled = true;
+                function = ReadOnlyFunction.SET;
 
-            Refresh();
-        }
-
-        /// <summary>
-        /// Shows appropriate confirmation dialog then calls DiskpartProcess.SetReadOnly
-        /// </summary>
-        /// <param name="function"></param>
-        private void SetReadOnly(ReadOnlyFunction function)
-        {
-            if (MessageHelper.ShowConfirm("Are you sure you want to " + function + " the read-only flag on " + SelectedVolume.Info + "?") == MessageBoxResult.Yes)
+            if (MessageHelper.ShowConfirm("Are you sure you want to " + function + " the read-only flag on " + SelectedVolume.ToString() + "?") == MessageBoxResult.Yes)
             {
                 if (function == ReadOnlyFunction.SET)
                 {
@@ -291,8 +282,9 @@ namespace DiskpartGUI.ViewModels
                     if (DiskpartProcess.ClearReadOnly(SelectedVolume) != ProcessExitCode.Ok)
                         ShowError(nameof(SetReadOnly));
                 }
+                Refresh();
             }
-
+            masterbuttonsenabled = true;
         }
 
         /// <summary>

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -70,7 +70,7 @@
                             <MenuItem Command="{Binding ChangeMountStateCommand}" Header="{Binding EjectMountButtonContent, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" InputGestureText="CTRL+E"/>
                             <MenuItem Command="{Binding RenameCommand}" Header="Rename" InputGestureText="F2"/>
                             <MenuItem Command="{Binding FormatCommand}" Header="Format" InputGestureText="CTRL+F"/>
-                            <MenuItem Command="{Binding ReadOnlyCommand}" Header="{Binding SetClearReadOnlyButtonContent, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" InputGestureText="CTRL+O"/>
+                            <MenuItem Command="{Binding ReadOnlyCommand}" Header="{Binding SetClearReadOnlyButtonContent, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" InputGestureText="CTRL+SHIFT+R"/>
                             <Separator/>
                             <MenuItem Command="{Binding BitLockCommand}" Header="Open BitLock" InputGestureText="CTRL+B"/>
                             <MenuItem Command="{Binding RefreshCommand}" Header="Refresh" InputGestureText="CTRL+R"/>


### PR DESCRIPTION
	- MainWindowViewModel.cs
		- Removed SetReadOnly(ReadOnlyFunction) method
			- Compressed into one SetReadOnly method
		- Fixed Refresh after cancel of SetReadOnly method
	- MainWindow.xaml
		- Changed MenuContext ReadOnlyCommand InputGestureText to CTRL+SHIFT+R