### PR TITLE
Branch BaseApplyCancelWindow

### DIFF
--- a/Commands/ApplyCommand.cs
+++ b/Commands/ApplyCommand.cs
@@ -1,0 +1,11 @@
+﻿using DiskpartGUI.ViewModels;
+using System.Windows.Input;
+
+namespace DiskpartGUI.Commands
+{
+    class ApplyCommand : RelayCommand
+    {
+        public ApplyCommand(ApplyCancelViewModel model)
+            : base(model.Apply, model.CanApply, Key.Enter) { }
+    }
+}

--- a/Commands/CancelCommand.cs
+++ b/Commands/CancelCommand.cs
@@ -1,0 +1,11 @@
+﻿using DiskpartGUI.ViewModels;
+using System.Windows.Input;
+
+namespace DiskpartGUI.Commands
+{
+    class CancelCommand : RelayCommand
+    {
+        public CancelCommand(ApplyCancelViewModel model)
+            : base(model.Cancel, Key.Escape) { }
+    }
+}

--- a/ViewModels/AboutWindowViewModel.cs
+++ b/ViewModels/AboutWindowViewModel.cs
@@ -34,7 +34,7 @@ namespace DiskpartGUI.ViewModels
         {
             get
             {
-                return "This program is free software. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE";
+                return "This program is free software. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
             }
         }
 

--- a/ViewModels/ApplyCancelViewModel.cs
+++ b/ViewModels/ApplyCancelViewModel.cs
@@ -30,20 +30,20 @@ namespace DiskpartGUI.ViewModels
         /// <summary>
         /// The RelayCommand for Apply to be used with bindings
         /// </summary>
-        public RelayCommand ApplyCommand { get; private set; }
+        public ApplyCommand ApplyCommand { get; private set; }
 
         /// <summary>
         /// The RelayCommand for Cancel to be used with bindings
         /// </summary>
-        public RelayCommand CancelCommand { get; private set; }
+        public CancelCommand CancelCommand { get; private set; }
 
         /// <summary>
         /// Sets up Apply and Cancel Commands
         /// </summary>
         public ApplyCancelViewModel() : base()
         {
-            ApplyCommand = new RelayCommand(Apply, CanApply, Key.Enter);
-            CancelCommand = new RelayCommand(Cancel, Key.Escape);
+            ApplyCommand = new ApplyCommand(this);
+            CancelCommand = new CancelCommand(this);
             ExitStatus = ExitStatus.Closed;
         }
 

--- a/Views/BaseApplyCancelWindow.cs
+++ b/Views/BaseApplyCancelWindow.cs
@@ -1,0 +1,29 @@
+﻿using DiskpartGUI.ViewModels;
+using System.Windows.Input;
+using System.Windows;
+using DiskpartGUI.Commands;
+
+namespace DiskpartGUI.Views
+{
+    public class BaseApplyCancelWindow : BaseClosableWindow
+    {
+        public BaseApplyCancelWindow() : base() { }
+
+        public BaseApplyCancelWindow(object dataContext) : base(dataContext) { }
+
+        protected override void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            base.Window_Loaded(sender, e);
+
+            RelayCommand c = new ApplyCommand((ApplyCancelViewModel)DataContext);
+            KeyGesture keyGesture = new KeyGesture(c.KeyGesture, c.GestureModifier);
+            KeyBinding kb = new KeyBinding(c, keyGesture);
+            InputBindings.Add(kb);
+
+            c = new CancelCommand((ApplyCancelViewModel)DataContext);
+            keyGesture = new KeyGesture(c.KeyGesture, c.GestureModifier);
+            kb = new KeyBinding(c, keyGesture);
+            InputBindings.Add(kb);
+        }
+    }
+}

--- a/Views/BaseClosableWindow.cs
+++ b/Views/BaseClosableWindow.cs
@@ -8,10 +8,7 @@ namespace DiskpartGUI.Views
         /// <summary>
         /// Default Constructor
         /// </summary>
-        public BaseClosableWindow() : base()
-        {
-            Loaded += Window_Loaded;
-        }
+        public BaseClosableWindow() : this(null) { }
 
         /// <summary>
         /// Constructor to set the DataContext
@@ -36,6 +33,6 @@ namespace DiskpartGUI.Views
             }
         }
 
-        
+
     }
 }

--- a/Views/FormatWindow.xaml
+++ b/Views/FormatWindow.xaml
@@ -1,4 +1,4 @@
-﻿<local:BaseClosableWindow 
+﻿<local:BaseApplyCancelWindow 
         x:Class="DiskpartGUI.Views.FormatWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,10 +10,6 @@
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize">
-    <Window.InputBindings>
-        <KeyBinding Command="{Binding ApplyCommand}" Key="{Binding ApplyCommand.KeyGesture}" Modifiers="{Binding ApplyCommand.GestureModifier}"/>
-        <KeyBinding Command="{Binding CancelCommand}" Key="{Binding CancelCommand.KeyGesture}" Modifiers="{Binding CancelCommand.GestureModifier}"/>
-    </Window.InputBindings>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -82,4 +78,4 @@
 
 
     </Grid>
-</local:BaseClosableWindow>
+</local:BaseApplyCancelWindow>

--- a/Views/FormatWindow.xaml.cs
+++ b/Views/FormatWindow.xaml.cs
@@ -4,7 +4,7 @@ namespace DiskpartGUI.Views
     /// <summary>
     /// Interaction logic for FormatWindow.xaml
     /// </summary>
-    public partial class FormatWindow : BaseClosableWindow
+    public partial class FormatWindow : BaseApplyCancelWindow
     {
         public FormatWindow(object dataContext) : base(dataContext)
         {

--- a/Views/RenameWindow.xaml
+++ b/Views/RenameWindow.xaml
@@ -1,4 +1,4 @@
-﻿<local:BaseClosableWindow
+﻿<local:BaseApplyCancelWindow
         x:Class="DiskpartGUI.Views.RenameWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -10,10 +10,6 @@
         SizeToContent="WidthAndHeight"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize">
-    <Window.InputBindings>
-        <KeyBinding Command="{Binding ApplyCommand}" Key="{Binding ApplyCommand.KeyGesture}" Modifiers="{Binding ApplyCommand.GestureModifier}"/>
-        <KeyBinding Command="{Binding CancelCommand}" Key="{Binding CancelCommand.KeyGesture}" Modifiers="{Binding CancelCommand.GestureModifier}"/>
-    </Window.InputBindings>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -49,4 +45,4 @@
         </Grid>
 
     </Grid>
-</local:BaseClosableWindow>
+</local:BaseApplyCancelWindow>

--- a/Views/RenameWindow.xaml.cs
+++ b/Views/RenameWindow.xaml.cs
@@ -4,7 +4,7 @@ namespace DiskpartGUI.Views
     /// <summary>
     /// Interaction logic for RenameWindow.xaml
     /// </summary>
-    public partial class RenameWindow : BaseClosableWindow
+    public partial class RenameWindow : BaseApplyCancelWindow
     {
         public RenameWindow(object dataContext) : base(dataContext)
         {


### PR DESCRIPTION
	- ApplyCommand.cs
		- Inital class setup
			- Extension of RelayCommand specific for apply buttons
	- CancelCommand.cs
		- Inital class setup
			- Extension of RelayCommand specific for cancel buttons
	- AboutWindowViewModel.cs
		- Added period at end of Information property string
	- ApplyCancelViewModel.cs
		- Changed ApplyCommand property to type ApplyCommand
		- Changed CancelCommand property to type CancelCommand
	- BaseApplyCancelWindow.cs
		- Inital class setup
			- Base window that sets up apply and cancel button commands
	- BaseClosableWindow.cs
		- Changed base() constructor to this() constructor
	- FormatWindow.xaml
		- Changed Window type to BaseApplyCancelWindow
		- Removed Window.InputBindings
	- FormatWindow.xaml.cs
		- Changed base class to BaseApplyCancelWindow
	- RenameWindow.xaml
		- Changed Window type to BaseApplyCancelWindow
		- Removed Window.InputBindings
	- RenameWindow.xaml.cs
		- Changed base class to BaseApplyCancelWindow