### PR TITLE
Branch FormatWindow

### DIFF
--- a/ViewModels/FormatWindowViewModel.cs
+++ b/ViewModels/FormatWindowViewModel.cs
@@ -24,8 +24,10 @@ namespace DiskpartGUI.ViewModels
         private string revisiontext;
         private bool quick;
         private bool comp;
+        private bool cancomp;
         private bool over;
         private bool dup;
+        private bool candup;
         private bool comboboxunitsizeenabled;
         private bool textboxrevisionenabled;
         private Lazy<DiskpartProcess> ldpp = new Lazy<DiskpartProcess>(() => new DiskpartProcess());
@@ -94,6 +96,16 @@ namespace DiskpartGUI.ViewModels
             set
             {
                 fs = value;
+                if (value == FileSystem.NTFS)
+                {
+                    CanCompress = true;
+                }
+                else
+                {
+                    CanCompress = false;
+                    Compress = false;
+                }
+
                 if (value == FileSystem.Default)
                 {
                     ComboBoxUnitSizeIsEnabled = false;
@@ -196,6 +208,19 @@ namespace DiskpartGUI.ViewModels
             }
         }
 
+        public bool CanCompress
+        {
+            get
+            {
+                return cancomp;
+            }
+            set
+            {
+                cancomp = value;
+                OnPropertyChanged(nameof(CanCompress));
+            }
+        }
+
         /// <summary>
         /// The Override format option
         /// </summary>
@@ -225,6 +250,19 @@ namespace DiskpartGUI.ViewModels
             {
                 dup = value;
                 OnPropertyChanged(nameof(Duplicate));
+            }
+        }
+
+        public bool CanDuplicate
+        {
+            get
+            {
+                return candup;
+            }
+            set
+            {
+                candup = value;
+                OnPropertyChanged(nameof(CanDuplicate));
             }
         }
 

--- a/Views/FormatWindow.xaml
+++ b/Views/FormatWindow.xaml
@@ -60,13 +60,13 @@
             <CheckBox Name="CheckBoxQuick" Content="Quick Format" Margin="5" IsChecked="{Binding QuickFormat, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="0" HorizontalAlignment="Left"/>
 
             <!-- Compress -->
-            <CheckBox Name="CheckBoxCompress" Content="Compress" Margin="5" IsChecked="{Binding Compress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="1" HorizontalAlignment="Left"/>
+            <CheckBox Name="CheckBoxCompress" Content="Compress" Margin="5" IsChecked="{Binding Compress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding CanCompress, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="1" HorizontalAlignment="Left"/>
 
             <!-- Override -->
             <CheckBox Name="CheckBoxOverride" Content="Override" Margin="5" IsChecked="{Binding Override, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="2" HorizontalAlignment="Left"/>
 
             <!-- Duplicate -->
-            <CheckBox Name="CheckBoxDuplicate" Content="Duplicate" Margin="5" IsChecked="{Binding Duplicate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="3" HorizontalAlignment="Left"/>
+            <CheckBox Name="CheckBoxDuplicate" Content="Duplicate" Margin="5" IsChecked="{Binding Duplicate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding CanDuplicate, UpdateSourceTrigger=PropertyChanged}" Grid.Column="0" Grid.Row="3" HorizontalAlignment="Left"/>
 
         </Grid>
 


### PR DESCRIPTION
	- FormatWindowViewModel.cs
		- Added CanCompress property
			- Should only be true when NTFS file system is selected
		- Added CanDupliate property
			- Should only be true when UDF file system is slected
			- Note: UDF file system is not implemented therefore Duplicate should always be disabled
	-FormatWindow.xaml
		- Added IsChecked binding to CheckBoxCompress
		- Added IsChecked binding to CheckBoxDuplicate